### PR TITLE
Use regexps for filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Link Filter
-Add-on for extracting and filtering links on web pages. Also ignores any javascript code that the page might run when clicking any links directly.
+Add-on for extracting and filtering links on web pages. Also ignores any JavaScript code that the page might run when clicking any links directly. Searches are performed using
+regular expressions.
 
 Install from [Mozilla Add-ons website](https://addons.mozilla.org/en-US/firefox/addon/link-filter/).
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "homepage_url": "https://github.com/milzer/firefox-link-filter",
   "manifest_version": 2,
   "name": "Link Filter",
-  "version": "1.1",
+  "version": "2.0",
 
   "description": "Filters links",
 
@@ -12,7 +12,8 @@
   },
 
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "storage"
   ],
 
   "browser_action": {

--- a/popup/link-filter.css
+++ b/popup/link-filter.css
@@ -2,6 +2,7 @@ html, body {
   font-family: Arial, Helvetica, sans-serif;
   overflow-x: hidden;
   min-width: 400px;
+  max-width: 900px;
 }
 
 li {
@@ -13,6 +14,7 @@ li {
   text-overflow: ellipsis;
 }
 
+
 .segment {
   display: flex;
   flex-direction: column;
@@ -21,9 +23,33 @@ li {
   padding: 4px;
 }
 
+.segment > h1 {
+  font-size: 1.3em;
+}
+
+.info-box {
+  width: 100%;
+  display: block;
+  padding: 4px;
+}
+
+.info-box > h1 {
+  font-size: 1.3em;
+  font-weight: bold;
+  margin: 0 0 0.25em;
+}
+
+.info-box > p {
+  margin: 0 0 0.2em;
+}
+
 #controls,
 #results {
   border-bottom: 1px solid #ddd;
+}
+
+input {
+  font-size: 1.1em;
 }
 
 .field {

--- a/popup/link-filter.html
+++ b/popup/link-filter.html
@@ -10,16 +10,24 @@
 
 <body>
   <div id="popup-content">
+    <div class="info-box">
+      <h1>Filter Links</h1>
+      <p>Filter using regular expression syntax.</p>
+    </div>
     <div class="segment" id="controls">
-      <input
-        class="field"
-        id="input-filter"
-        placeholder="filter"
-        autofocus
-        type="text"
-        name="filter" />
+      <label>
+        Regexp:
+        <input
+          class="field"
+          id="input-filter"
+          placeholder="filter"
+          autofocus
+          type="search"
+          name="filter" />
+      </label>
     </div>
     <div class="segment" id="results">
+      <h1>Matching links:</h1>
     </div>
   </div>
   <div id="error-content" class="hidden segment">

--- a/popup/link-filter.js
+++ b/popup/link-filter.js
@@ -54,13 +54,27 @@ const render = (links, onLinkClick) => {
 }
 
 const filter = (filter, links) => {
+  /*
   return !!filter ?
     links.filter((link) => link.text.toLowerCase().includes(filter.toLowerCase())) :
-    links;
+    links; */
+
+  // Treating filter as a regular expression
+
+  if (!filter || !filter.length) {
+    filter = ".*";
+  }
+  const re = new RegExp(filter, "gi");
+  return !!re ?
+    links.filter(((link) => {
+      const linktext = link.text;
+      return re.test(linktext);
+    })) : links;
 }
 
 const _update = (links, onLinkClick) => () => {
   const filterInput = document.getElementById('input-filter');
+  chrome.storage.local.set({"filter": filterInput.value});
   const filtered = filter(filterInput.value, links);
   render(filtered, onLinkClick);
 }
@@ -81,6 +95,13 @@ const init = ([tab]) => {
   getLinks(({links}) => {
     update = _update(links, onLinkClick);
     update();
+  });
+
+  // Restore the contents of the input from last
+  // time we were open
+  
+  chrome.storage.local.get("filter", function(result) {
+    filterInput.value = result.filter || "";
   });
 }
 


### PR DESCRIPTION
With this patch, the addon uses regular expressions to do its
filtering. Also, a number of visual improvements have been made,
tidying up the appearance a bit. Also, the contents of the input
field are now preserved across opening the addon's popup, which
is useful when browsing through the searched list of links.